### PR TITLE
Fix Firefox freezing problem

### DIFF
--- a/src/components/Facet.vue
+++ b/src/components/Facet.vue
@@ -14,7 +14,7 @@ const toggleAll = (f: FacetCollection) => {
 }
 const facetsSorted = computed(() => {
     return Object.values(props.facets).map(v => {
-        v.items.sort((a, b) => {
+        [...v.items].sort((a, b) => {
             return a.count > b.count ? -1 : 1
         })
         return v


### PR DESCRIPTION
Seems sorting facets in place leads to recursion in Firefox. 
I'm not sure why it only happens on Firefox and not Chrome. I tested it on Firefox Mac and Android and both had the same problem.
Firefox profiler result: [https://share.firefox.dev/3StX4Mt](https://share.firefox.dev/3StX4Mt)