### PR TITLE
chore: add danger color for light theme

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -31,6 +31,7 @@ body.light{
   --hl-bg2: #9d9d9d;
   --hl-bg3: #8c8c8c;
   --bg-btn: #c5c5c5;
+  --danger: #ff8282;
   --info: rgb(145, 155, 186);
 }
 


### PR DESCRIPTION
Fix: https://github.com/logdyhq/logdy-ui/issues/7

Use a different color for danger in the light theme

![image](https://github.com/user-attachments/assets/72ceca21-3e94-4f81-ae2e-d4ae3291b28a)
