### PR TITLE
[#107] support serving main.wasm via subpath

### DIFF
--- a/src/breser.ts
+++ b/src/breser.ts
@@ -3,7 +3,7 @@
 export const BreserInit = async () => {
     //@ts-expect-error
     const go = new Go();
-    const result = await WebAssembly.instantiateStreaming(fetch("/main.wasm"), go.importObject)
+    const result = await WebAssembly.instantiateStreaming(fetch(window.location.pathname + "main.wasm"), go.importObject)
     go.run(result.instance)
 }
 


### PR DESCRIPTION
This PR is to support logdyhq/logdy-core#107 to serve main.wasm via subpath