### PR TITLE
Fix: enable and synchronize Pause button in demo mode

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -64,7 +64,7 @@ export const useMainStore = defineStore("main", () => {
     const confirmShow = ref<boolean>(false);
 
     const status = ref<"connected" | "not connected">("not connected")
-    const receiveStatus = ref<ReceiveStatus>("paused")
+    const receiveStatus = ref<ReceiveStatus>(demoMode.value ? "following" : "paused")
     const receiveCounters = ref<ReceiveCounters>({ LastDeliveredIdx: 0, MessageCount: 0, MessagesToTail: 0 })
     const anotherTab = ref<boolean>(false)
     const modalShow = ref<"" | "auth" | "import" | "export-logs" | "load-logs" | "feedback">("")
@@ -276,14 +276,23 @@ export const useMainStore = defineStore("main", () => {
             case 'following':
                 await client.resume()
                 receiveStatus.value = 'following';
+                if (demoMode.value) {
+                    demoStatus.value = 'started'
+                }
                 break;
             case 'following_cursor':
                 await client.resumeFromCursor()
                 receiveStatus.value = 'following_cursor';
+                if (demoMode.value) {
+                    demoStatus.value = 'started'
+                }
                 break;
             case 'paused':
                 await client.pause()
                 receiveStatus.value = 'paused';
+                if (demoMode.value) {
+                    demoStatus.value = 'stopped'
+                }
                 break;
         }
     }


### PR DESCRIPTION
# Fix: Pause Button Non-Functional in UI-Only Demo Mode

## Summary

Resolves an issue where the **Pause** button in the top toolbar was non-functional and incorrectly disabled when running Logdy in UI-only demo mode (`?demo_mode=true`).

---

## The Problem

### 1. Initial State Mismatch
`receiveStatus` was initialized to `"paused"` by default. In demo mode, since there is no backend check-in to update this value, the Pause button remained **disabled on startup** — even though logs were actively flowing.

### 2. Lack of Synchronization
The main toolbar's Pause/Play buttons only updated the WebSocket `receiveStatus`. They had **no effect on the `demoStatus` variable**, which is responsible for controlling the local demo message generator in `App.vue`.

---

## The Fix

### 1. Correct Initialization — `store.ts`
Updated `receiveStatus` to initialize as `"following"` when `demoMode` is active. This ensures the Pause button is **enabled immediately** when the demo starts.

### 2. State Synchronization — `store.ts`
Updated the `changeReceiveStatus` function to also toggle `demoStatus` (`'started'` / `'stopped'`) whenever the user interacts with the Pause or Play buttons while in demo mode — keeping both states in sync.